### PR TITLE
Shut down on long press

### DIFF
--- a/Diabolo_Light.cpp
+++ b/Diabolo_Light.cpp
@@ -21,7 +21,7 @@ static unsigned int current_mode; // 0 is the off mode, 1-num_modes inclusive ar
 
 static void (*on_wake_up)();
 static unsigned long wake_up_time;
-static unsigned int hold_time;
+static unsigned int begin_hold_time;
 static bool has_just_woken_up; // If this is true, the user needs to hold the button for the mode to increment
 
 /*!
@@ -60,15 +60,15 @@ ISR(PCINT0_vect) {
              Call this in the setup function.
     @param   num_modes  the number of modes the board should have
              not including the off mode
-    @param   hold_time  the amount of time in milliseconds the user has to
+    @param   begin_hold_time  the amount of time in milliseconds the user has to
              hold the button in order for the board to turn on. Defaults to
              500ms.
     @param   on_wake_up additional things the board should do when the button
              is pressed to wake up the board. Defaults to doing nothing.
 */
-void Diabolo_Light::begin(const unsigned int num_modes, const unsigned int hold_time, void (*on_wake_up)()) {
+void Diabolo_Light::begin(const unsigned int num_modes, const unsigned int begin_hold_time, void (*on_wake_up)()) {
     ::num_modes = num_modes;
-    ::hold_time = hold_time;
+    ::begin_hold_time = begin_hold_time;
     ::on_wake_up = on_wake_up;
 
     ADCSRA &= ~(1 << ADEN); // Disable ADC
@@ -93,7 +93,7 @@ void Diabolo_Light::begin(const unsigned int num_modes, const unsigned int hold_
              non-blocking or else current_mode will not update.
 */
 void Diabolo_Light::handle_button() {
-    if (has_just_woken_up && awake_time() >= hold_time) {
+    if (has_just_woken_up && awake_time() >= begin_hold_time) {
         has_just_woken_up = false;
         first_press = true;
         current_mode = current_mode >= num_modes ? 0 : current_mode + 1;

--- a/Diabolo_Light.cpp
+++ b/Diabolo_Light.cpp
@@ -90,7 +90,7 @@ void Diabolo_Light::begin(const unsigned int num_modes, const unsigned int hold_
              non-blocking or else current_mode will not update.
 */
 void Diabolo_Light::handle_button() {
-    if (has_just_woken_up && millis() - wake_up_time >= hold_time) {
+    if (has_just_woken_up && awake_time() >= hold_time) {
         has_just_woken_up = false;
         current_mode = current_mode >= num_modes ? 0 : current_mode + 1;
         digitalWrite(MOSFET_PIN, LOW); // Connect the LEDs

--- a/Diabolo_Light.h
+++ b/Diabolo_Light.h
@@ -8,7 +8,8 @@ namespace Diabolo_Light {
     const unsigned int NUM_LEDS = 6;
     const neoPixelType LED_TYPE = NEO_RGB + NEO_KHZ800;
 
-    void begin(const unsigned int num_modes, const unsigned int begin_hold_time = 500, void (*on_wake_up)() = [](){});
+    // FIXME: add line breaks? I don't usually code in C++, not sure what's appropriate.
+    void begin(const unsigned int num_modes, const unsigned int begin_hold_time = 500, const unsigned int end_hold_time = 2000, void (*on_wake_up)() = [](){});
     void handle_button();
     unsigned int get_current_mode();
     void set_current_mode(const unsigned int new_mode);

--- a/Diabolo_Light.h
+++ b/Diabolo_Light.h
@@ -8,7 +8,7 @@ namespace Diabolo_Light {
     const unsigned int NUM_LEDS = 6;
     const neoPixelType LED_TYPE = NEO_RGB + NEO_KHZ800;
 
-    void begin(const unsigned int num_modes, const unsigned int hold_time = 500, void (*on_wake_up)() = [](){});
+    void begin(const unsigned int num_modes, const unsigned int begin_hold_time = 500, void (*on_wake_up)() = [](){});
     void handle_button();
     unsigned int get_current_mode();
     void set_current_mode(const unsigned int new_mode);


### PR DESCRIPTION
Previously, with many modes, all would need to be cycled through in order to shut down. This adds the ability to shut down from any mode.

See other commits for changes necessary to support this feature.